### PR TITLE
Updated templates for Legion raids

### DIFF
--- a/templates/group-history.html
+++ b/templates/group-history.html
@@ -19,11 +19,11 @@ Killed
 <tr>
   <td class="history-group-header">{{ history.date }}</td>
   <td style="padding-left:10px">
-    {{- addentry('Hellfire Citadel', 'Mythic', 'M', num_nh_bosses, history.nh.mythic, history.nh.mythic_total) -}}
-    {{- addentry('Hellfire Citadel', 'Heroic', 'H', num_nh_bosses, history.nh.heroic, history.nh.heroic_total) -}}
-    {{- addentry('Hellfire Citadel', 'Normal', 'N', num_nh_bosses, history.nh.normal, history.nh.normal_total) -}}
-    {{- addentry('Blackrock Foundry', 'Mythic', 'M', num_en_bosses, history.en.mythic, history.en.mythic_total) -}}
-    {{- addentry('Blackrock Foundry', 'Heroic', 'H', num_en_bosses, history.en.heroic, history.en.heroic_total) -}}
-    {{- addentry('Blackrock Foundry', 'Normal', 'N', num_en_bosses, history.en.normal, history.en.normal_total) -}}
+    {{- addentry('The Nighthold', 'Mythic', 'M', num_nh_bosses, history.nh.mythic, history.nh.mythic_total) -}}
+    {{- addentry('The Nighthold', 'Heroic', 'H', num_nh_bosses, history.nh.heroic, history.nh.heroic_total) -}}
+    {{- addentry('The Nighthold', 'Normal', 'N', num_nh_bosses, history.nh.normal, history.nh.normal_total) -}}
+    {{- addentry('The Emerald Nightmare', 'Mythic', 'M', num_en_bosses, history.en.mythic, history.en.mythic_total) -}}
+    {{- addentry('The Emerald Nightmare', 'Heroic', 'H', num_en_bosses, history.en.heroic, history.en.heroic_total) -}}
+    {{- addentry('The Emerald Nightmare', 'Normal', 'N', num_en_bosses, history.en.normal, history.en.normal_total) -}}
   </td>
 </tr>

--- a/templates/group-history.html
+++ b/templates/group-history.html
@@ -19,14 +19,11 @@ Killed
 <tr>
   <td class="history-group-header">{{ history.date }}</td>
   <td style="padding-left:10px">
-    {{- addentry('Hellfire Citadel', 'Mythic', 'M', num_hfc_bosses, history.hfc.mythic, history.hfc.mythic_total) -}}
-    {{- addentry('Hellfire Citadel', 'Heroic', 'H', num_hfc_bosses, history.hfc.heroic, history.hfc.heroic_total) -}}
-    {{- addentry('Hellfire Citadel', 'Normal', 'N', num_hfc_bosses, history.hfc.normal, history.hfc.normal_total) -}}
-    {{- addentry('Blackrock Foundry', 'Mythic', 'M', num_brf_bosses, history.brf.mythic, history.brf.mythic_total) -}}
-    {{- addentry('Blackrock Foundry', 'Heroic', 'H', num_brf_bosses, history.brf.heroic, history.brf.heroic_total) -}}
-    {{- addentry('Blackrock Foundry', 'Normal', 'N', num_brf_bosses, history.brf.normal, history.brf.normal_total) -}}
-    {{- addentry('Highmaul', 'Mythic', 'M', num_hm_bosses, history.hm.mythic, history.hm.mythic_total) -}}
-    {{- addentry('Highmaul', 'Heroic', 'H', num_hm_bosses, history.hm.heroic, history.hm.heroic_total) -}}
-    {{- addentry('Highmaul', 'Normal', 'N', num_hm_bosses, history.hm.normal, history.hm.normal_total) }}
+    {{- addentry('Hellfire Citadel', 'Mythic', 'M', num_nh_bosses, history.nh.mythic, history.nh.mythic_total) -}}
+    {{- addentry('Hellfire Citadel', 'Heroic', 'H', num_nh_bosses, history.nh.heroic, history.nh.heroic_total) -}}
+    {{- addentry('Hellfire Citadel', 'Normal', 'N', num_nh_bosses, history.nh.normal, history.nh.normal_total) -}}
+    {{- addentry('Blackrock Foundry', 'Mythic', 'M', num_en_bosses, history.en.mythic, history.en.mythic_total) -}}
+    {{- addentry('Blackrock Foundry', 'Heroic', 'H', num_en_bosses, history.en.heroic, history.en.heroic_total) -}}
+    {{- addentry('Blackrock Foundry', 'Normal', 'N', num_en_bosses, history.en.normal, history.en.normal_total) -}}
   </td>
 </tr>

--- a/templates/history.html
+++ b/templates/history.html
@@ -19,11 +19,11 @@ Killed
 <tr>
   <td class="history-group-header">{{ history.group }}</td>
   <td style="padding-left:10px">
-    {{- addentry('Hellfire Citadel', 'Mythic', 'M', num_nh_bosses, history.nh.mythic, history.nh.mythic_total) -}}
-    {{- addentry('Hellfire Citadel', 'Heroic', 'H', num_nh_bosses, history.nh.heroic, history.nh.heroic_total) -}}
-    {{- addentry('Hellfire Citadel', 'Normal', 'N', num_nh_bosses, history.nh.normal, history.nh.normal_total) -}}
-    {{- addentry('Blackrock Foundry', 'Mythic', 'M', num_en_bosses, history.en.mythic, history.en.mythic_total) -}}
-    {{- addentry('Blackrock Foundry', 'Heroic', 'H', num_en_bosses, history.en.heroic, history.en.heroic_total) -}}
-    {{- addentry('Blackrock Foundry', 'Normal', 'N', num_en_bosses, history.en.normal, history.en.normal_total) -}}
+    {{- addentry('The Nighthold', 'Mythic', 'M', num_nh_bosses, history.nh.mythic, history.nh.mythic_total) -}}
+    {{- addentry('The Nighthold', 'Heroic', 'H', num_nh_bosses, history.nh.heroic, history.nh.heroic_total) -}}
+    {{- addentry('The Nighthold', 'Normal', 'N', num_nh_bosses, history.nh.normal, history.nh.normal_total) -}}
+    {{- addentry('The Emerald Nightmare', 'Mythic', 'M', num_en_bosses, history.en.mythic, history.en.mythic_total) -}}
+    {{- addentry('The Emerald Nightmare', 'Heroic', 'H', num_en_bosses, history.en.heroic, history.en.heroic_total) -}}
+    {{- addentry('The Emerald Nightmare', 'Normal', 'N', num_en_bosses, history.en.normal, history.en.normal_total) -}}
   </td>
 </tr>

--- a/templates/history.html
+++ b/templates/history.html
@@ -19,14 +19,11 @@ Killed
 <tr>
   <td class="history-group-header">{{ history.group }}</td>
   <td style="padding-left:10px">
-    {{- addentry('Hellfire Citadel', 'Mythic', 'M', num_hfc_bosses, history.hfc.mythic, history.hfc.mythic_total) -}}
-    {{- addentry('Hellfire Citadel', 'Heroic', 'H', num_hfc_bosses, history.hfc.heroic, history.hfc.heroic_total) -}}
-    {{- addentry('Hellfire Citadel', 'Normal', 'N', num_hfc_bosses, history.hfc.normal, history.hfc.normal_total) -}}
-    {{- addentry('Blackrock Foundry', 'Mythic', 'M', num_brf_bosses, history.brf.mythic, history.brf.mythic_total) -}}
-    {{- addentry('Blackrock Foundry', 'Heroic', 'H', num_brf_bosses, history.brf.heroic, history.brf.heroic_total) -}}
-    {{- addentry('Blackrock Foundry', 'Normal', 'N', num_brf_bosses, history.brf.normal, history.brf.normal_total) -}}
-    {{- addentry('Highmaul', 'Mythic', 'M', num_hm_bosses, history.hm.mythic, history.hm.mythic_total) -}}
-    {{- addentry('Highmaul', 'Heroic', 'H', num_hm_bosses, history.hm.heroic, history.hm.heroic_total) -}}
-    {{- addentry('Highmaul', 'Normal', 'N', num_hm_bosses, history.hm.normal, history.hm.normal_total) }}
+    {{- addentry('Hellfire Citadel', 'Mythic', 'M', num_nh_bosses, history.nh.mythic, history.nh.mythic_total) -}}
+    {{- addentry('Hellfire Citadel', 'Heroic', 'H', num_nh_bosses, history.nh.heroic, history.nh.heroic_total) -}}
+    {{- addentry('Hellfire Citadel', 'Normal', 'N', num_nh_bosses, history.nh.normal, history.nh.normal_total) -}}
+    {{- addentry('Blackrock Foundry', 'Mythic', 'M', num_en_bosses, history.en.mythic, history.en.mythic_total) -}}
+    {{- addentry('Blackrock Foundry', 'Heroic', 'H', num_en_bosses, history.en.heroic, history.en.heroic_total) -}}
+    {{- addentry('Blackrock Foundry', 'Normal', 'N', num_en_bosses, history.en.normal, history.en.normal_total) -}}
   </td>
 </tr>


### PR DESCRIPTION
As far as I could see in display.py, just needed to change hfc/brf/hm to nh/en.  It looked to me like the addentry blocks for full history and group history are identical code; changed both.  I'm not sure I have any way to test this?  Should I be cloning it on my home computer and running it in the dev console locally?  I'd assume I'd need to re-create your keys file with my own keys to make anything work.
